### PR TITLE
Decrease min required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8.0)
+cmake_minimum_required(VERSION 3.5.1)
 
 project (meltdown)
 


### PR DESCRIPTION
Tested on Ubuntu Trusty LTS (cmake 3.5.1)